### PR TITLE
Lazy data-driven initialization

### DIFF
--- a/causallib/contrib/hemm/hemm.py
+++ b/causallib/contrib/hemm/hemm.py
@@ -111,7 +111,7 @@ class HEMM(torch.nn.Module):
         std = std.unsqueeze(0)
 
         gauss_ = -torch.log(std) - torch.div((x - mu.expand(x.shape)) ** 2, 2 * (std ** 2))
-        gauss_ = torch.sum(gauss_, dim=1) - 0.9189 * x.shape[1]  # TODO: what's with the 0.9189?
+        gauss_ = torch.sum(gauss_, dim=1) + np.log(1 / np.sqrt(2 * np.pi)) * x.shape[1]
 
         return gauss_
 

--- a/causallib/contrib/tests/test_hemm.py
+++ b/causallib/contrib/tests/test_hemm.py
@@ -48,11 +48,9 @@ class TestHemmEstimator(unittest.TestCase):
             outcome_model = BalancedNet(Xte.shape[1], Xte.shape[1], 1)
 
         estimator = HEMM(
-            Xte.shape[1],
             comp,
             mu=mu,
             std=std,
-            bc=6,
             lamb=0.,
             spread=0.,
             outcome_model=outcome_model,

--- a/examples/hemm_demo.ipynb
+++ b/examples/hemm_demo.ipynb
@@ -179,8 +179,6 @@
     "Yte  = syn_data['TEST']['yf'][:  , 0]\n",
     "Tte  = syn_data['TEST']['t'] [:  , 0]\n",
     "\n",
-    "#Feature size\n",
-    "Xdim = Xtr.shape[1]\n",
     "\n",
     "#Number of Components to Discover.\n",
     "K = 3\n",
@@ -203,7 +201,7 @@
     "outcome_model='linear'\n",
     "\n",
     "#Instantiate an HEMM model\n",
-    "model = HEMM(Xdim, K, homo=True, mu=mu, std=std, bc=2, lamb=0.0000,\\\n",
+    "model = HEMM(K, homo=True, mu=mu, std=std, lamb=0.0000,\\\n",
     "                spread=.1,outcome_model=outcome_model,sep_heads=True,epochs=10,\\\n",
     "                 learning_rate=learning_rate,weight_decay=0.0001,metric='LL', use_p_correction=False,\\\n",
     "                 response=response,imb_fun=None,batch_size=batch_size )\n",
@@ -604,7 +602,7 @@
     "from causallib.contrib.hemm.outcome_models import genMLPModule, genLinearModule, BalancedNet\n",
     "\n",
     "\n",
-    "def experiment(data, i, K=2, response='bin', outcomeModel='linear', lr=1e-3, batch_size=100, vsize=0.3, bc=2, epochs=20):\n",
+    "def experiment(data, i, K=2, response='bin', outcomeModel='linear', lr=1e-3, batch_size=100, vsize=0.3, epochs=20):\n",
     "    \n",
     "    vsize = int(vsize*data['TRAIN']['x'].shape[0])\n",
     "    \n",
@@ -638,9 +636,7 @@
     "    elif outcomeModel == 'CF':\n",
     "        outcomeModel = BalancedNet(Xte.shape[1], Xte.shape[1], 1 )\n",
     "        \n",
-    "    Xdim = Xte.shape[1]\n",
-    "        \n",
-    "    model = HEMM(Xdim, K, homo=True, mu=mu, std=std, bc=bc, lamb=0.0000,\\\n",
+    "    model = HEMM(K, homo=True, mu=mu, std=std, lamb=0.0000,\\\n",
     "                spread=.01,outcome_model=outcome_model,sep_heads=True,epochs=epochs,\\\n",
     "                 learning_rate=learning_rate,weight_decay=0.0001,metric='LL', use_p_correction=False,\\\n",
     "                 response=response,imb_fun=None,batch_size=batch_size )\n",
@@ -769,7 +765,7 @@
    "source": [
     "from joblib import Parallel, delayed\n",
     "\n",
-    "PEHEs = Parallel(n_jobs=10)(delayed(experiment)(data=ihdp_data, i=i,outcomeModel='CF', K=3,lr=1e-3,vsize=0.25, batch_size=10, bc=6, response='cont', epochs=500) for i in range(10))"
+    "PEHEs = Parallel(n_jobs=10)(delayed(experiment)(data=ihdp_data, i=i,outcomeModel='CF', K=3,lr=1e-3,vsize=0.25, batch_size=10, response='cont', epochs=500) for i in range(10))"
    ]
   },
   {


### PR DESCRIPTION
Remove data-related parameters from constructor.
Let them be inferred automatically from the data once data is introduce (during first `fit()` call).

This requires a two-step lazy initialization:
 * First `__init__` call mostly saves parameters internally.
 * First `fit()` call will initialize the statistical model (e.g., define priors, build model, etc.) 

Parameters affected are input dimension (`D_in`) and the positioning of binary variable in the column order `bc`.
Specific column order is no longer required. 

I'm consider whether to also remove `mu` and `std` from `__init__` and provide them only in `fit()`.
They are currently able to be provided in fit (if not provided they are overridden with whatever `mu` and `std` were provided in the constructor, so this is still backward compatible)

______________________
Also, replaced the implicit `-0.91893` with explicit `np.log(1 / np.sqrt(2 * np.pi))` in `gauss_pdf()`.