### PR TITLE
Move priors specification from constructor to `fit()`

### DIFF
--- a/causallib/contrib/hemm/hemm.py
+++ b/causallib/contrib/hemm/hemm.py
@@ -67,7 +67,7 @@ class HEMM(torch.nn.Module):
         self.expert = None
 
 
-    def initialize_model(self, mu=None, std=None):
+    def _initialize_model(self, mu=None, std=None):
         """Data-dependent initialization. Definitions required once we know how the data looks like."""
         if self.outcome_model == 'linear':
             self.outcome_model = nn.Linear(self._bc.size, 2)  # Assumes 2 treatment values
@@ -234,7 +234,7 @@ class HEMM(torch.nn.Module):
         binary_columns = torch.all((x == 0) | (x == 1), dim=0)
         self._bc = binary_columns
         if not self._is_initialized:
-            self.initialize_model(init_mu, init_std)
+            self._initialize_model(init_mu, init_std)
 
         if dev is not None:
             xdev, tdev, ydev = dev

--- a/causallib/contrib/hemm/hemm.py
+++ b/causallib/contrib/hemm/hemm.py
@@ -45,8 +45,7 @@ class HEMM(torch.nn.Module):
         sep_heads: Setting false will force the adjustment of Confounding to be same independent of treatment assignment.
     """
 
-    def __init__(self, K, homo=True, mu=None, std=None, lamb=0.0001, spread=0.1,
-                 outcomeModel='linear', sep_heads=True):
+    def __init__(self, K, homo=True, lamb=0.0001, spread=0.1, outcomeModel='linear', sep_heads=True):
 
         super(HEMM, self).__init__()
         self.lamb = lamb
@@ -56,19 +55,19 @@ class HEMM(torch.nn.Module):
 
         self.spread = spread
         self.outcome_model = outcomeModel
-        self.mu = mu
-        self.std = std
 
         # Will be initialized once data introduced:
         self._is_initialized = False  # Whether model has been initialized
         self._bc = None  # Binary mask of which columns are binary columns, rest will consider continuous
         self.p = None
+        self.mu = None
+        self.std = None
         self.alph = None
         self.treat = None
         self.expert = None
 
 
-    def initialize_model(self, mu, std):
+    def initialize_model(self, mu=None, std=None):
         """Data-dependent initialization. Definitions required once we know how the data looks like."""
         if self.outcome_model == 'linear':
             self.outcome_model = nn.Linear(self._bc.size, 2)  # Assumes 2 treatment values
@@ -234,11 +233,6 @@ class HEMM(torch.nn.Module):
 
         binary_columns = torch.all((x == 0) | (x == 1), dim=0)
         self._bc = binary_columns
-
-        if init_mu is None:
-            init_mu = self.mu
-        if init_std is None:
-            init_std = self.std
         if not self._is_initialized:
             self.initialize_model(init_mu, init_std)
 

--- a/causallib/contrib/hemm/hemm_api.py
+++ b/causallib/contrib/hemm/hemm_api.py
@@ -32,16 +32,14 @@ class HEMM(IndividualOutcomeEstimator):
     """
 
     def __init__(self,
-                 K, homo=True, mu=None, std=None, lamb=1e-4, spread=0.1, outcome_model='linear',
+                 K, homo=True, lamb=1e-4, spread=0.1, outcome_model='linear',
                  sep_heads=True, epochs=100, batch_size=10, learning_rate=1e-3, weight_decay=0.1, elbo_loss=True,
                  metric='AP', response='bin', use_p_correction=True, imb_fun='mmd2_lin', p_alpha=1e-4, random_seed=0):
         """Instantiate estimator.
 
         Args:
-            K (int): Number of components to discover. (specifcy K-1: eg. For 2 components use K=1)
-            homo: 
-            mu (float): Initialize the components with means of the training data.
-            std (float): Initialize the components with std dev of the training data.
+            K (int): Number of components to discover. (specify K-1: eg. For 2 components use K=1)
+            homo:
             lamb (float): Strength of the beta(0.5, 0.5) prior on the bernoulli variables.
             spread (float): How far should the components be initailized from there means.
             outcome_model (str): 'linear' to specify a linear outcome function.
@@ -78,7 +76,7 @@ class HEMM(IndividualOutcomeEstimator):
         
         torch.manual_seed(random_seed)
 
-        model = HEMMTorch(K=K, homo=homo, mu=mu, std=std, lamb=lamb, spread=spread,
+        model = HEMMTorch(K=K, homo=homo, lamb=lamb, spread=spread,
                           outcomeModel=outcome_model, sep_heads=sep_heads)
         model = model.double()
         super(HEMM, self).__init__(learner=model)
@@ -166,8 +164,8 @@ class HEMM(IndividualOutcomeEstimator):
             y (torch.Tensor | pd.Series | np.ndarray): Observed outcome of size (num_subjects,).
             sample_weight: *IGNORED*
             validation_data: tuple of validation set: (X_val, a_val, y_val) corresponding to `X, a, y` above.
-            init_mu (np.ndarray): initialize the components with provided means.
-            init_std (np.ndarray): initialize the components with provided std.
+            init_mu (np.ndarray): Prior initialization of the components with provided means.
+            init_std (np.ndarray): Prior initialization of the components with provided std.
 
         Returns:
             IndividualOutcomeEstimator: A causal weight model with an inner learner fitted.

--- a/causallib/contrib/tests/test_hemm.py
+++ b/causallib/contrib/tests/test_hemm.py
@@ -49,8 +49,6 @@ class TestHemmEstimator(unittest.TestCase):
 
         estimator = HEMM(
             comp,
-            mu=mu,
-            std=std,
             lamb=0.,
             spread=0.,
             outcome_model=outcome_model,
@@ -62,7 +60,7 @@ class TestHemmEstimator(unittest.TestCase):
             response=response,
             imb_fun='wass'
         )
-        estimator.fit(Xtr, Ttr, Ytr, validation_data=(Xdev, Tdev, Ydev))
+        estimator.fit(Xtr, Ttr, Ytr, validation_data=(Xdev, Tdev, Ydev), init_mu=mu, init_std=std)
 
         Xtr = data['TRAIN']['x'][:, :, i]
         Ttr = data['TRAIN']['t'][:, i]

--- a/examples/hemm_demo.ipynb
+++ b/examples/hemm_demo.ipynb
@@ -201,7 +201,7 @@
     "outcome_model='linear'\n",
     "\n",
     "#Instantiate an HEMM model\n",
-    "model = HEMM(K, homo=True, mu=mu, std=std, lamb=0.0000,\\\n",
+    "model = HEMM(K, homo=True, lamb=0.0000,\\\n",
     "                spread=.1,outcome_model=outcome_model,sep_heads=True,epochs=10,\\\n",
     "                 learning_rate=learning_rate,weight_decay=0.0001,metric='LL', use_p_correction=False,\\\n",
     "                 response=response,imb_fun=None,batch_size=batch_size )\n",
@@ -209,7 +209,7 @@
     "\n",
     "#Fit the HEMM model on the Training Data, with Early Stopping\n",
     "#on the Dev Set.\n",
-    "cd = model.fit(Xtr, Ttr,Ytr, validation_data=(Xdev, Tdev, Ydev))\n"
+    "cd = model.fit(Xtr, Ttr,Ytr, validation_data=(Xdev, Tdev, Ydev), init_mu=mu, init_std=std)\n"
    ]
   },
   {
@@ -636,14 +636,14 @@
     "    elif outcomeModel == 'CF':\n",
     "        outcomeModel = BalancedNet(Xte.shape[1], Xte.shape[1], 1 )\n",
     "        \n",
-    "    model = HEMM(K, homo=True, mu=mu, std=std, lamb=0.0000,\\\n",
+    "    model = HEMM(K, homo=True, lamb=0.0000,\\\n",
     "                spread=.01,outcome_model=outcome_model,sep_heads=True,epochs=epochs,\\\n",
     "                 learning_rate=learning_rate,weight_decay=0.0001,metric='LL', use_p_correction=False,\\\n",
     "                 response=response,imb_fun=None,batch_size=batch_size )\n",
     "\n",
     "    \n",
     "\n",
-    "    cd = model.fit(Xtr, Ttr,Ytr, validation_data=(Xdev, Tdev, Ydev))\n",
+    "    cd = model.fit(Xtr, Ttr,Ytr, validation_data=(Xdev, Tdev, Ydev), init_mu=mu, init_std=std)\n",
     "    \n",
     "    inSampleCFoutcomes  = model.estimate_individual_outcome(Xtr, Ttr)\n",
     "    outSampleCFoutcomes = model.estimate_individual_outcome(Xte, Tte)\n",


### PR DESCRIPTION
Separate data-related initialization from model specification entirely by specifying the priors (initial parameters) during `fit()` - when data is introduced, instead during construction when model is just broadly defined.

(From what I understand, these initial parameters are used to specify the data's averages and stds, i.e. sort of empirical-Bayes. I guess a nicer way to do that is to specify an `empirical` model parameter, and let these calculations take place during `fit`, so this burden is not on the user. but I'll understand if that's too much for now... 😄  )